### PR TITLE
Allow sanitized markup in toastr message area

### DIFF
--- a/development/Menu.js
+++ b/development/Menu.js
@@ -30,7 +30,7 @@ export default class Menu extends React.Component {
         <li className="success" onClick={() => {
           toastr.success(
             'In the beginning was the word',
-            'and the Word was with God, and the Word was God...',
+            'and <a href="/heaven/">the Word</a> was with God, and the Word was God...',
             {
               timeOut: 10000,
               position: 'top-left',

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.3",
+    "dompurify": "^1.0.11",
     "eventemitter3": "^3.1.0"
   },
   "homepage": "https://github.com/diegoddox/react-redux-toastr#readme"

--- a/src/ToastrBox.js
+++ b/src/ToastrBox.js
@@ -1,5 +1,6 @@
 import React, {isValidElement} from 'react'; //  eslint-disable-line no-unused-vars
 import PropTypes from 'prop-types';
+import dompurify from 'dompurify';
 import classnames from 'classnames';
 import ProgressBar from './ProgressBar';
 import Icon from './Icon';
@@ -218,6 +219,11 @@ export default class ToastrBox extends React.Component {
       title
     } = this.props.item;
 
+    const getMarkup = (string) => {
+      const sanitize = dompurify.sanitize;
+      return {__html: sanitize(string)};
+    } 
+
     return (
       <div>
         <div className="rrt-left-container">
@@ -228,7 +234,7 @@ export default class ToastrBox extends React.Component {
         {options.status && type === 'light' && <div className={classnames('toastr-status', options.status)}/>}
         <div className="rrt-middle-container" role="alertdialog" aria-labelledby={`dialogTitle-${this.id}`} aria-describedby={`dialogDesc-${this.id}`}>
           {title && <div id={`dialogTitle-${this.id}`} className="rrt-title">{title}</div>}
-          {message && <div id={`dialogDesc-${this.id}`} className="rrt-text">{message}</div>}
+          {message && <div id={`dialogDesc-${this.id}`} className="rrt-text"><span dangerouslySetInnerHTML={getMarkup(message)} /></div>}
           {options.component && this.renderSubComponent()}
         </div>
 


### PR DESCRIPTION
Greets Diego, 

I've added code that allows react-redux-toastr to display markup in it's messages. This was accomplished using: 
1. **domputify** to do the html sanitization, see: https://github.com/cure53/DOMPurify
2. **React's dangerouslySetInnerHTML** to display the markup after sanitization, see: https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml

I didn't bother making this an optional feature (to make this easier for you to review) but it probably should be? 

If you like the idea of allowing markup then I'll wire in a [configuration var](https://github.com/diegoddox/react-redux-toastr#4-add-the-component-into-an-app-root), maybe something like allowHtml: false, and make sure that all the [toastr methods](https://github.com/diegoddox/react-redux-toastr#toastr-methods) play nice with the new feature. I'll update [the manual](https://github.com/diegoddox/react-redux-toastr/blob/master/README.md) along the way too if you accept this change.

Thanks Diego. Let me know if you're cool with allowing markup in the message area of the react-redux-toastr display.

-Dan